### PR TITLE
[build] fix iOS zip GitHub Action

### DIFF
--- a/.github/workflows/dev_release_ci.yml
+++ b/.github/workflows/dev_release_ci.yml
@@ -148,7 +148,7 @@ jobs:
           path: apolline-flutter/build/ios/iphoneos/Runner.app
 
       - name: Zip release
-        uses: papeloto/action-zip@v1
+        uses: vimtor/action-zip@v1
         with:
           files: apolline-flutter/build/ios/iphoneos/Runner.app
           dest: Apolline-iOS.zip       


### PR DESCRIPTION
It seems that used Action was renamed, thus breaking this CI.
https://github.com/vimtor/action-zip/issues/14