### PR TITLE
build: Update CI deprecated actions

### DIFF
--- a/.github/workflows/dev_release_ci.yml
+++ b/.github/workflows/dev_release_ci.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
@@ -55,7 +55,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
@@ -125,7 +125,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
       - name: Generate configuration file

--- a/.github/workflows/dev_release_ci.yml
+++ b/.github/workflows/dev_release_ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/dev_release_ci.yml
+++ b/.github/workflows/dev_release_ci.yml
@@ -92,7 +92,7 @@ jobs:
         
       - name: Get compilation time
         id: date
-        run: echo "::set-output name=date::$(date +'%d-%m-%Y %H:%M:%S')"
+        run: echo date=\"$(date +'%d-%m-%Y %H:%M:%S')\" >> $GITHUB_ENV
 
       - name: Save build artefact
         uses: actions/upload-artifact@v1
@@ -107,7 +107,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: android-dev-release
           allowUpdates: true
-          body: This is the latest Android development version of the Apolline application (created on ${{ steps.date.outputs.date }}).
+          body: This is the latest Android development version of the Apolline application (created on ${{ env.date }}).
 
 
   build-iOS:
@@ -142,7 +142,7 @@ jobs:
         
       - name: Get compilation time
         id: date
-        run: echo "::set-output name=date::$(date +'%d-%m-%Y %H:%M:%S')"
+        run: echo date=\"$(date +'%d-%m-%Y %H:%M:%S')\" >> $GITHUB_ENV
 
       - name: Save build artefact
         uses: actions/upload-artifact@v1
@@ -163,4 +163,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ios-dev-release
           allowUpdates: true
-          body: This is the latest iOS development version of the Apolline application (created on ${{ steps.date.outputs.date }}).
+          body: This is the latest iOS development version of the Apolline application (created on ${{ env.date }}).

--- a/.github/workflows/dev_release_ci.yml
+++ b/.github/workflows/dev_release_ci.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1
@@ -49,8 +50,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1
@@ -118,8 +120,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1

--- a/.github/workflows/dev_release_ci.yml
+++ b/.github/workflows/dev_release_ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:
@@ -123,7 +123,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
@@ -58,7 +58,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
@@ -100,7 +100,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
       - name: Generate configuration file

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -18,8 +18,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1
@@ -52,8 +53,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1
@@ -93,8 +95,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:
@@ -98,7 +98,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2.8.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'temurin'
-          java-version: '12.x'
+          java-version: '11.0.16+101'
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.5.0
         with:
+          distribution: 'temurin'
           java-version: '12.x'
       - name: Install Flutter
         uses: subosito/flutter-action@v1

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v3.1.0
       - name: Install Java
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Some actions and methods used in CI are going to, or are already deprecated, so we update them.

![image](https://user-images.githubusercontent.com/11993538/195827248-dc6f5063-31f4-4801-8270-2a51a7a3ef3b.png)

![image](https://user-images.githubusercontent.com/11993538/195827323-14d5f6fd-3aa8-46e8-9009-690b3fba9bb7.png)
