### PR TITLE
fix: Scan button

### DIFF
--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -231,10 +231,13 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
       ];
     } else {
       return <Widget>[
-        SizedBox(
-          child: CircularProgressIndicator(backgroundColor: Theme.of(context).primaryColor, color: Colors.white,),
-          width: 20,
-          height: 20,
+        Container(
+          margin: EdgeInsets.only(right: 10),
+          child: SizedBox(
+            child: CircularProgressIndicator(backgroundColor: Theme.of(context).primaryColor, color: Colors.white,),
+            width: 20,
+            height: 20,
+          ),
         ),
         Text("devicesView.analysisButton.cancel", style: btnStyle).tr(),
       ];

--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -247,6 +247,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
           print("pressed!");
           _onPressLookforButton();
         },
+        style: TextButton.styleFrom(padding: EdgeInsets.symmetric(horizontal: 15)),
         child: Row(children: _buildChildrenButton()),
       );
   }

--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -227,8 +227,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
 
     if (timeout) {
       return <Widget>[
-        TextButton(onPressed: () {  },
-        child: Text("devicesView.analysisButton.analyse", style: btnStyle,).tr()),
+        Text("devicesView.analysisButton.analyse", style: btnStyle,).tr(),
       ];
     } else {
       return <Widget>[
@@ -237,22 +236,19 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
           width: 20,
           height: 20,
         ),
-        TextButton(onPressed: () {  },
-        child: Text("devicesView.analysisButton.cancel", style: btnStyle).tr()),
+        Text("devicesView.analysisButton.cancel", style: btnStyle).tr(),
       ];
     }
   }
 
-  List<Widget> _buildAppBarAction() {
-    List<Widget> wList = <Widget>[
-      TextButton(
+  Widget _buildAppBarAction() {
+    return TextButton(
         onPressed: () {
+          print("pressed!");
           _onPressLookforButton();
         },
         child: Row(children: _buildChildrenButton()),
-      ),
-    ];
-    return wList;
+      );
   }
 
   /* UI update only */
@@ -272,7 +268,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
         // Here we take the value from the MyHomePage object that was created by
         // the App.build method, and use it to set our appbar title.
         title: Text("devicesView.title").tr(),
-        actions: _buildAppBarAction(),
+        actions: [ _buildAppBarAction() ],
       ),
       body: Center(
           // Center is a layout widget. It takes a single child and positions it

--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -213,7 +213,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
   }
 
   ///
-  ///Exécuter lorsqu'on clique sur le button Annalyser ou Arreter
+  ///Exécuter lorsqu'on clique sur le button Analyser ou Arreter
   void _onPressLookforButton() {
     if (timeout == true) {
       initializeDevice();
@@ -246,10 +246,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
 
   Widget _buildAppBarAction() {
     return TextButton(
-        onPressed: () {
-          print("pressed!");
-          _onPressLookforButton();
-        },
+        onPressed: _onPressLookforButton,
         style: TextButton.styleFrom(padding: EdgeInsets.symmetric(horizontal: 15)),
         child: Row(children: _buildChildrenButton()),
       );


### PR DESCRIPTION
The "scan devices" button had some buttons encased in it, which prevented its onpress method from triggering, thus preventing devices scanning.