### PR TITLE
fix: Add missing semicolon to xcode project

### DIFF
--- a/apolline-flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/apolline-flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				MARKETING_VERSION = 1.8.1
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.science.apollineflutter.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Fix a typo added in https://github.com/Apolline-Lille/apolline-flutter/commit/fdf850c9b1155ffa3a5d4ee07d47ac30bdcca08b#diff-514515ff61fbf393f3c4f387599c566195b7944aafc80e1a97d28ed4daebf99aR430