### PR TITLE
refactor: Events dialog

### DIFF
--- a/apolline-flutter/assets/translations/en-GB.json
+++ b/apolline-flutter/assets/translations/en-GB.json
@@ -121,7 +121,9 @@
     "types": {
       "disconnection": "Disconnected from sensor",
       "connection": "Connected to sensor",
-      "liveData": "Air quality data received (live)"
+      "liveData": "Air quality data received (live)",
+      "dataSendingOk": "Data sent successfully to server",
+      "dataSendingFailed": "Failed sending data to server"
     }
   },
   "endpointDialog": {

--- a/apolline-flutter/assets/translations/fr-FR.json
+++ b/apolline-flutter/assets/translations/fr-FR.json
@@ -121,7 +121,9 @@
     "types": {
       "disconnection": "Déconnecté du capteur",
       "connection": "Connecté au capteur",
-      "liveData": "Données de qualité de l'air reçues (live)"
+      "liveData": "Données de qualité de l'air reçues (live)",
+      "dataSendingOk": "Données transférées au serveur",
+      "dataSendingFailed": "Echec de l'envoi des données au serveur"
     }
   },
   "endpointDialog": {

--- a/apolline-flutter/lib/services/influxdb_client.dart
+++ b/apolline-flutter/lib/services/influxdb_client.dart
@@ -4,6 +4,9 @@ import 'dart:io';
 import 'package:apollineflutter/exception/bad_request_exception.dart';
 import 'package:apollineflutter/exception/lost_connection_exception.dart';
 import 'package:apollineflutter/models/server_endpoint_handler.dart';
+import 'package:apollineflutter/services/service_locator.dart';
+import 'package:apollineflutter/services/user_configuration_service.dart';
+import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
 import 'package:http/http.dart' as http;
 
 
@@ -36,12 +39,12 @@ class InfluxDBAPI {
 
   ///
   ///write data to influx database
-  Future<void> write(String data, {String token = ""}) async {
+  Future<void> write(String data, {String token = "", required String deviceName}) async {
     bool useTokenAuth = token.isNotEmpty;
 
     return useTokenAuth
-        ? await client.postSilent("$_connectionString/write?db=$_db", body: data, headers: {'Authorization': 'Token $token'}, encoding: Encoding.getByName("utf-8")!)
-        : await client.postSilent("$_connectionString/write?db=$_db&u=$_username&p=$_password", body: data, headers: {}, encoding: Encoding.getByName("utf-8")!);
+        ? await client.postSilent("$_connectionString/write?db=$_db", deviceName, body: data, headers: {'Authorization': 'Token $token'}, encoding: Encoding.getByName("utf-8")!)
+        : await client.postSilent("$_connectionString/write?db=$_db&u=$_username&p=$_password", deviceName, body: data, headers: {}, encoding: Encoding.getByName("utf-8")!);
   }
 
   ///
@@ -70,6 +73,7 @@ class InfluxDBAPI {
 class _InfluxDBClient extends http.BaseClient {
   static const OKSTATUS = [204, 200];
   http.Client _inner;
+  final UserConfigurationService _ucS = locator<UserConfigurationService>();
 
   ///
   ///constructor
@@ -100,7 +104,7 @@ class _InfluxDBClient extends http.BaseClient {
 
   ///
   ///post.
-  Future<void> postSilent(url, {required Map<String, String> headers, body, required Encoding encoding}) async {
+  Future<void> postSilent(url, String deviceName, {required Map<String, String> headers, body, required Encoding encoding}) async {
     http.Response resp;
     try{
       resp = await this.post(Uri.parse(url), headers: headers, body: body, encoding: encoding);
@@ -108,6 +112,13 @@ class _InfluxDBClient extends http.BaseClient {
       throw LostConnectionException("server is unavailable ${e.toString()}");
     }
 
+    // log event
+    _ucS.userConf.addSensorEvent(
+        deviceName,
+        resp.statusCode == 204
+            ? SensorEventType.DataSendingOk
+            : SensorEventType.DataSendingFail
+    );
     print(resp.body);
 
     if(!OKSTATUS.contains(resp.statusCode) ) {

--- a/apolline-flutter/lib/twins/SensorTwin.dart
+++ b/apolline-flutter/lib/twins/SensorTwin.dart
@@ -231,7 +231,11 @@ class SensorTwin {
       // Send data to influxDB
       List<DataPointModel> models = dataPoints.sublist(lowerBound, upperBound);
       print('Sending ${models.length} data points to InfluxDB');
-      await _service.write(DataPointModel.sensorsFmtToInfluxData(models), token: this._databaseToken);
+      await _service.write(
+          DataPointModel.sensorsFmtToInfluxData(models),
+          deviceName: this.name,
+          token: this._databaseToken
+      );
 
       // Update local data in sqfLite
       List<int> ids = models.map((model) => model.id).toList();

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -23,7 +23,13 @@ extension SensorEventTypeUtils on SensorEventType {
 
   String get label {
     if (SensorEventTypeUtils._labels[this] == null)
-      throw RangeError("This SensorEventType has no associated label.");
+      throw RangeError("This SensorEventType has no associated data.");
     return SensorEventTypeUtils._labels[this]!.label.tr();
+  }
+
+  Color get color {
+    if (SensorEventTypeUtils._labels[this] == null)
+      throw RangeError("This SensorEventType has no associated data.");
+    return SensorEventTypeUtils._labels[this]!.color;
   }
 }

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -1,14 +1,17 @@
 import 'package:easy_localization/easy_localization.dart';
 
 enum SensorEventType {
-  Connection, Disconnection, LiveData
+  Connection, Disconnection, LiveData,
+  DataSendingOk, DataSendingFail
 }
 
 extension SensorEventTypeUtils on SensorEventType {
   static final Map<SensorEventType, String> _labels = {
     SensorEventType.Connection: "events.types.connection",
     SensorEventType.Disconnection: "events.types.disconnection",
-    SensorEventType.LiveData: "events.types.liveData"
+    SensorEventType.LiveData: "events.types.liveData",
+    SensorEventType.DataSendingOk: "events.types.dataSendingOk",
+    SensorEventType.DataSendingFail: "events.types.dataSendingFailed"
   };
 
   String get label {

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -17,8 +17,8 @@ extension SensorEventTypeUtils on SensorEventType {
     SensorEventType.Connection: _SensorEventTypeData("events.types.connection", Colors.green.shade100),
     SensorEventType.Disconnection: _SensorEventTypeData("events.types.disconnection", Colors.red.shade100),
     SensorEventType.LiveData: _SensorEventTypeData("events.types.liveData", Colors.white),
-    SensorEventType.DataSendingOk: _SensorEventTypeData("events.types.dataSendingOk", Colors.white),
-    SensorEventType.DataSendingFail: _SensorEventTypeData("events.types.dataSendingFailed", Colors.white)
+    SensorEventType.DataSendingOk: _SensorEventTypeData("events.types.dataSendingOk", Colors.blue.shade50),
+    SensorEventType.DataSendingFail: _SensorEventTypeData("events.types.dataSendingFailed", Colors.red.shade100)
   };
 
   String get label {

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -1,22 +1,29 @@
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
 
 enum SensorEventType {
   Connection, Disconnection, LiveData,
   DataSendingOk, DataSendingFail
 }
 
+class _SensorEventTypeData {
+  final String label;
+  final Color color;
+  _SensorEventTypeData(this.label, this.color);
+}
+
 extension SensorEventTypeUtils on SensorEventType {
-  static final Map<SensorEventType, String> _labels = {
-    SensorEventType.Connection: "events.types.connection",
-    SensorEventType.Disconnection: "events.types.disconnection",
-    SensorEventType.LiveData: "events.types.liveData",
-    SensorEventType.DataSendingOk: "events.types.dataSendingOk",
-    SensorEventType.DataSendingFail: "events.types.dataSendingFailed"
+  static final Map<SensorEventType, _SensorEventTypeData> _labels = {
+    SensorEventType.Connection: _SensorEventTypeData("events.types.connection", Colors.green.shade100),
+    SensorEventType.Disconnection: _SensorEventTypeData("events.types.disconnection", Colors.red.shade100),
+    SensorEventType.LiveData: _SensorEventTypeData("events.types.liveData", Colors.white),
+    SensorEventType.DataSendingOk: _SensorEventTypeData("events.types.dataSendingOk", Colors.white),
+    SensorEventType.DataSendingFail: _SensorEventTypeData("events.types.dataSendingFailed", Colors.white)
   };
 
   String get label {
     if (SensorEventTypeUtils._labels[this] == null)
       throw RangeError("This SensorEventType has no associated label.");
-    return SensorEventTypeUtils._labels[this]!.tr();
+    return SensorEventTypeUtils._labels[this]!.label.tr();
   }
 }

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -42,19 +42,24 @@ class _EventsDialogState extends State<EventsDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Row(
-        children: [
-          Text(widget.deviceName),
-          Spacer(),
-          IconButton(
-              onPressed: () {
-                setState(() {
-                  _showLiveDataEvents = !_showLiveDataEvents;
-                });
-              },
-              icon: Icon(_showLiveDataEvents ? CupertinoIcons.eye_slash : CupertinoIcons.eye)
-          )
-        ],
+      titlePadding: EdgeInsets.all(0),
+      title: Container(
+        padding: EdgeInsets.only(right: 20, left: 20, top: 16, bottom: 0),
+        color: Colors.white,
+        child: Row(
+          children: [
+            Text(widget.deviceName),
+            Spacer(),
+            IconButton(
+                onPressed: () {
+                  setState(() {
+                    _showLiveDataEvents = !_showLiveDataEvents;
+                  });
+                },
+                icon: Icon(_showLiveDataEvents ? CupertinoIcons.eye_slash : CupertinoIcons.eye)
+            )
+          ],
+        )
       ),
       contentPadding: EdgeInsets.only(left: 0, bottom: 0, right: 0, top: 20),
       content: _hasEvents() ? Container(

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -26,26 +26,30 @@ class EventsDialog extends StatefulWidget {
 }
 
 class _EventsDialogState extends State<EventsDialog> {
+  bool _showLiveDataEvents = true;
+
   bool _hasEvents() {
     return ucS.userConf.getSensorEvents(widget.deviceName).isNotEmpty;
   }
 
   List<Widget> _getEventCards () {
     List<Widget> widgets = [];
-    ucS.userConf.getSensorEvents(widget.deviceName).forEach((event) {
-      widgets.add(
-          ListTile(
-              title: Text(event.type.label),
-              dense: event.type == SensorEventType.LiveData,
-              subtitle: Text(formatter.format(event.time).toString()),
-              tileColor: event.type == SensorEventType.Connection
-                  ? Colors.green.shade100
-                  : event.type == SensorEventType.Disconnection
-                  ? Colors.red.shade100
-                  : Colors.white
-          )
-      );
-    });
+    ucS.userConf.getSensorEvents(widget.deviceName)
+        .where((element) => !_showLiveDataEvents || _showLiveDataEvents && element.type != SensorEventType.LiveData)
+        .forEach((event) {
+          widgets.add(
+              ListTile(
+                  title: Text(event.type.label),
+                  dense: event.type == SensorEventType.LiveData,
+                  subtitle: Text(formatter.format(event.time).toString()),
+                  tileColor: event.type == SensorEventType.Connection
+                      ? Colors.green.shade100
+                      : event.type == SensorEventType.Disconnection
+                      ? Colors.red.shade100
+                      : Colors.white
+              )
+          );
+        });
     return widgets.reversed.toList();
   }
 

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -38,6 +38,7 @@ List<Widget> _getEventCards (String deviceName) {
     widgets.add(
       ListTile(
         title: Text(event.type.label),
+        dense: event.type == SensorEventType.LiveData,
         subtitle: Text(formatter.format(event.time).toString()),
         tileColor: event.type == SensorEventType.Connection
             ? Colors.green.shade100

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -33,7 +33,7 @@ class EventsDialog extends StatefulWidget {
 }
 
 class _EventsDialogState extends State<EventsDialog> {
-  bool _showLiveDataEvents = true;
+  bool _showLiveDataEvents = false;
 
   bool _hasEvents() {
     return widget.events.isNotEmpty;
@@ -49,10 +49,10 @@ class _EventsDialogState extends State<EventsDialog> {
           IconButton(
               onPressed: () {
                 setState(() {
-                _showLiveDataEvents = !_showLiveDataEvents;
+                  _showLiveDataEvents = !_showLiveDataEvents;
                 });
               },
-              icon: Icon(_showLiveDataEvents ? CupertinoIcons.eye : CupertinoIcons.eye_slash)
+              icon: Icon(_showLiveDataEvents ? CupertinoIcons.eye_slash : CupertinoIcons.eye)
           )
         ],
       ),
@@ -62,7 +62,7 @@ class _EventsDialogState extends State<EventsDialog> {
           width: 300,
           child: ListView(
             children: widget.events
-                .where((element) => !_showLiveDataEvents || _showLiveDataEvents && element.type != SensorEventType.LiveData)
+                .where((element) => _showLiveDataEvents || !_showLiveDataEvents && element.type != SensorEventType.LiveData)
                 .map((event) => ListTile(
                     title: Text(event.type.label),
                     dense: event.type == SensorEventType.LiveData,

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -11,42 +11,58 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
   showDialog(
       context: context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: Text(deviceName),
-          contentPadding: EdgeInsets.only(left: 0, bottom: 0, right: 0, top: 20),
-          content: _hasEventsForSensor(deviceName) ? Container(
-              height: 300,
-              width: 300,
-              child: ListView(
-                children: _getEventCards(deviceName),
-              )
-          ) : ListTile(
-            title: Text("events.noEventsText").tr(),
-          ),
-        );
+        return EventsDialog(deviceName: deviceName);
       }
   );
 }
 
-bool _hasEventsForSensor(String deviceName) {
-  return ucS.userConf.getSensorEvents(deviceName).isNotEmpty;
+
+class EventsDialog extends StatefulWidget {
+  final String deviceName;
+  EventsDialog({required this.deviceName});
+
+  @override
+  State<StatefulWidget> createState() => _EventsDialogState();
 }
 
-List<Widget> _getEventCards (String deviceName) {
-  List<Widget> widgets = [];
-  ucS.userConf.getSensorEvents(deviceName).forEach((event) {
-    widgets.add(
-      ListTile(
-        title: Text(event.type.label),
-        dense: event.type == SensorEventType.LiveData,
-        subtitle: Text(formatter.format(event.time).toString()),
-        tileColor: event.type == SensorEventType.Connection
-            ? Colors.green.shade100
-            : event.type == SensorEventType.Disconnection
-              ? Colors.red.shade100
-              : Colors.white
-      )
+class _EventsDialogState extends State<EventsDialog> {
+  bool _hasEvents() {
+    return ucS.userConf.getSensorEvents(widget.deviceName).isNotEmpty;
+  }
+
+  List<Widget> _getEventCards () {
+    List<Widget> widgets = [];
+    ucS.userConf.getSensorEvents(widget.deviceName).forEach((event) {
+      widgets.add(
+          ListTile(
+              title: Text(event.type.label),
+              dense: event.type == SensorEventType.LiveData,
+              subtitle: Text(formatter.format(event.time).toString()),
+              tileColor: event.type == SensorEventType.Connection
+                  ? Colors.green.shade100
+                  : event.type == SensorEventType.Disconnection
+                  ? Colors.red.shade100
+                  : Colors.white
+          )
+      );
+    });
+    return widgets.reversed.toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.deviceName),
+      contentPadding: EdgeInsets.only(left: 0, bottom: 0, right: 0, top: 20),
+      content: _hasEvents() ? Container(
+          height: 300,
+          width: 300,
+          child: ListView(
+            children: _getEventCards(),
+          )
+      ) : ListTile(
+        title: Text("events.noEventsText").tr(),
+      ),
     );
-  });
-  return widgets.reversed.toList();
+  }
 }

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -2,6 +2,7 @@ import 'package:apollineflutter/services/service_locator.dart';
 import 'package:apollineflutter/services/user_configuration_service.dart';
 import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'SensorEvent.dart';
@@ -41,13 +42,26 @@ class _EventsDialogState extends State<EventsDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text(widget.deviceName),
+      title: Row(
+        children: [
+          Text(widget.deviceName),
+          Spacer(),
+          IconButton(
+              onPressed: () {
+                setState(() {
+                _showLiveDataEvents = !_showLiveDataEvents;
+                });
+              },
+              icon: Icon(_showLiveDataEvents ? CupertinoIcons.eye : CupertinoIcons.eye_slash)
+          )
+        ],
+      ),
       contentPadding: EdgeInsets.only(left: 0, bottom: 0, right: 0, top: 20),
       content: _hasEvents() ? Container(
           height: 300,
           width: 300,
           child: ListView(
-            children:  widget.events
+            children: widget.events
                 .where((element) => !_showLiveDataEvents || _showLiveDataEvents && element.type != SensorEventType.LiveData)
                 .map((event) => ListTile(
                     title: Text(event.type.label),

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -72,11 +72,7 @@ class _EventsDialogState extends State<EventsDialog> {
                     title: Text(event.type.label),
                     dense: event.type == SensorEventType.LiveData,
                     subtitle: Text(formatter.format(event.time).toString()),
-                    tileColor: event.type == SensorEventType.Connection
-                        ? Colors.green.shade100
-                        : event.type == SensorEventType.Disconnection
-                        ? Colors.red.shade100
-                        : Colors.white
+                    tileColor: event.type.color
                 )).toList().reversed.toList(),
           )
       ) : ListTile(

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -4,6 +4,8 @@ import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
+import 'SensorEvent.dart';
+
 final UserConfigurationService ucS = locator<UserConfigurationService>();
 final DateFormat formatter = DateFormat('dd-MM-yyyy HH:mm:ss');
 
@@ -11,7 +13,10 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
   showDialog(
       context: context,
       builder: (BuildContext context) {
-        return EventsDialog(deviceName: deviceName);
+        return EventsDialog(
+          deviceName: deviceName,
+          events: ucS.userConf.getSensorEvents(deviceName)
+        );
       }
   );
 }
@@ -19,7 +24,8 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
 
 class EventsDialog extends StatefulWidget {
   final String deviceName;
-  EventsDialog({required this.deviceName});
+  final List<SensorEvent> events;
+  EventsDialog({required this.deviceName, required this.events});
 
   @override
   State<StatefulWidget> createState() => _EventsDialogState();
@@ -29,12 +35,12 @@ class _EventsDialogState extends State<EventsDialog> {
   bool _showLiveDataEvents = true;
 
   bool _hasEvents() {
-    return ucS.userConf.getSensorEvents(widget.deviceName).isNotEmpty;
+    return widget.events.isNotEmpty;
   }
 
   List<Widget> _getEventCards () {
     List<Widget> widgets = [];
-    ucS.userConf.getSensorEvents(widget.deviceName)
+    widget.events
         .where((element) => !_showLiveDataEvents || _showLiveDataEvents && element.type != SensorEventType.LiveData)
         .forEach((event) {
           widgets.add(

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -38,27 +38,6 @@ class _EventsDialogState extends State<EventsDialog> {
     return widget.events.isNotEmpty;
   }
 
-  List<Widget> _getEventCards () {
-    List<Widget> widgets = [];
-    widget.events
-        .where((element) => !_showLiveDataEvents || _showLiveDataEvents && element.type != SensorEventType.LiveData)
-        .forEach((event) {
-          widgets.add(
-              ListTile(
-                  title: Text(event.type.label),
-                  dense: event.type == SensorEventType.LiveData,
-                  subtitle: Text(formatter.format(event.time).toString()),
-                  tileColor: event.type == SensorEventType.Connection
-                      ? Colors.green.shade100
-                      : event.type == SensorEventType.Disconnection
-                      ? Colors.red.shade100
-                      : Colors.white
-              )
-          );
-        });
-    return widgets.reversed.toList();
-  }
-
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -68,7 +47,18 @@ class _EventsDialogState extends State<EventsDialog> {
           height: 300,
           width: 300,
           child: ListView(
-            children: _getEventCards(),
+            children:  widget.events
+                .where((element) => !_showLiveDataEvents || _showLiveDataEvents && element.type != SensorEventType.LiveData)
+                .map((event) => ListTile(
+                    title: Text(event.type.label),
+                    dense: event.type == SensorEventType.LiveData,
+                    subtitle: Text(formatter.format(event.time).toString()),
+                    tileColor: event.type == SensorEventType.Connection
+                        ? Colors.green.shade100
+                        : event.type == SensorEventType.Disconnection
+                        ? Colors.red.shade100
+                        : Colors.white
+                )).toList().reversed.toList(),
           )
       ) : ListTile(
         title: Text("events.noEventsText").tr(),


### PR DESCRIPTION
* Now lists data sending results (either success or fail)
* "Sensor data received" events are display in smaller tiles (because they are lots of them)
    * Those events are hidden by default
    * They can be displayed via a button

---

##### Screenshots

<p align="center">
<img height="600px" src="https://user-images.githubusercontent.com/11993538/207567858-15ed51b3-327d-4ae6-90fa-cf93ebbb66b9.png"/>
<img height="600px" src="https://user-images.githubusercontent.com/11993538/207567952-120ed19c-8f30-4244-8f7c-54bd60ca7a68.png"/>

</p>